### PR TITLE
feat: add user identifier to backend requests

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -27,11 +27,7 @@ export default {
       IS_DEPLOYED: isDeployed,
       ...rawEnv,
     });
-    const polyratingsEnv = new Env(cloudflareEnv);
-
-    if (!cloudflareEnv.IS_DEPLOYED) {
-      // await ensureLocalDb(cloudflareEnv, polyratingsEnv);
-    }
+    const plan2GatherEnv = new Env(cloudflareEnv);
 
     return fetchRequestHandler({
       endpoint: '',
@@ -40,7 +36,10 @@ export default {
       batching: {
         enabled: false,
       },
-      createContext: async () => ({ env: polyratingsEnv }),
+      createContext: async ({ req }) => ({
+        env: plan2GatherEnv,
+        userId: req.headers.get('X-User-Identifier'),
+      }),
       responseMeta: () => ({
         headers: {
           'Access-Control-Max-Age': '1728000',

--- a/packages/backend/src/trpc.ts
+++ b/packages/backend/src/trpc.ts
@@ -3,6 +3,7 @@ import { Env } from './env';
 
 type Context = {
   env: Env;
+  userId: string | null;
 };
 
 export default initTRPC.context<Context>().create({});

--- a/packages/backend/src/types/schema.ts
+++ b/packages/backend/src/types/schema.ts
@@ -87,13 +87,18 @@ export type GatheringFormData = z.infer<typeof gatheringFormDataSchema>;
  * Gathering data schema.
  * The gathering data is the gathering form data with an ID and user availability.
  */
-export const gatheringDataSchema = z
-  .object({
-    ...gatheringFormDataSchema.shape,
-    id: z.string(),
-    availability: userAvailabilitySchema,
-    creationDate: validDatetimeSchema,
-  })
-  .readonly();
+export const gatheringDataSchema = z.object({
+  ...gatheringFormDataSchema.shape,
+  id: z.string(),
+  availability: userAvailabilitySchema,
+  creationDate: validDatetimeSchema,
+});
 
 export type GatheringData = z.infer<typeof gatheringDataSchema>;
+
+export const gatheringBackendDataSchema = z
+  .object({
+    creationUserId: z.string(),
+  })
+  .merge(gatheringDataSchema)
+  .readonly();

--- a/packages/frontend/src/app/app.tsx
+++ b/packages/frontend/src/app/app.tsx
@@ -27,7 +27,7 @@ export default function App() {
     });
     return client;
   });
-  const trpcClient = useMemo(() => trpc.createClient(trpcClientOptions()), []);
+  const trpcClient = useMemo(() => trpc.createClient(trpcClientOptions), []);
 
   const router = createBrowserRouter([
     { path: '*', element: <NotFound /> },

--- a/packages/frontend/src/hooks/user.store.ts
+++ b/packages/frontend/src/hooks/user.store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { nanoid } from 'nanoid';
+
+interface UserStore {
+  userId: string;
+  getUserId: () => string;
+}
+
+function getUserId() {
+  let userId = localStorage.getItem('userId');
+  if (!userId) {
+    userId = nanoid();
+    localStorage.setItem('userId', userId);
+  }
+  return userId;
+}
+
+const useUserStore = create<UserStore>((_, get) => ({
+  userId: getUserId(),
+  getUserId: () => get().userId,
+}));
+
+export default useUserStore;

--- a/packages/frontend/src/trpc.ts
+++ b/packages/frontend/src/trpc.ts
@@ -1,14 +1,18 @@
 import { createTRPCReact } from '@trpc/react-query';
-import { httpLink } from '@trpc/client';
+import { CreateTRPCClientOptions, httpLink } from '@trpc/client';
 import type { AppRouter } from '@plan2gather/backend';
 import { config } from './config';
+import useUserStore from './hooks/user.store';
 
 export const trpc = createTRPCReact<AppRouter>();
 
-export const trpcClientOptions = () => ({
+export const trpcClientOptions: CreateTRPCClientOptions<AppRouter> = {
   links: [
     httpLink({
       url: config.clientEnv.url,
+      headers: {
+        'X-User-Identifier': useUserStore.getState().getUserId(),
+      },
     }),
   ],
-});
+};

--- a/packages/frontend/src/utils/test-utils.tsx
+++ b/packages/frontend/src/utils/test-utils.tsx
@@ -7,7 +7,7 @@ import { trpc, trpcClientOptions } from '../trpc';
 // eslint-disable-next-line import/prefer-default-export
 export function TRPCWrapper({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
-  const trpcClient = useMemo(() => trpc.createClient(trpcClientOptions()), []);
+  const trpcClient = useMemo(() => trpc.createClient(trpcClientOptions), []);
 
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>


### PR DESCRIPTION
This generates a userId and adds it to the local storage. Every request to the backend through tRPC has the header attached to it.

In a follow up I'll modify the backend to attach a userId to the meeting creation and the UserAvailability